### PR TITLE
Corregidos los problemas compilando los examenes

### DIFF
--- a/examenes/bbdd-gcdia-2024-2025-ordinaria.tex
+++ b/examenes/bbdd-gcdia-2024-2025-ordinaria.tex
@@ -28,11 +28,11 @@ Podemos tener diferentes estructuras cerebrales, cada una identificada por un no
 \begin{solution}
 
 \begin{center}
-    \includegraphics[width=\textwidth]{examenes/figs/bbdd-gcdia-2024-2025-ordinaria-er.pdf}
+    \includegraphics[width=\textwidth]{figs/bbdd-gcdia-2024-2025-ordinaria-er.pdf}
 \end{center}
 
 \begin{center}
-    \includegraphics[width=\textwidth]{examenes/figs/bbdd-gcdia-2024-2025-ordinaria-tablas.pdf}
+    \includegraphics[width=\textwidth]{figs/bbdd-gcdia-2024-2025-ordinaria-tablas.pdf}
 \end{center}
 
 \end{solution}

--- a/examenes/db-exam.cls
+++ b/examenes/db-exam.cls
@@ -3,6 +3,7 @@
 
 \LoadClassWithOptions{exam}
 
+\RequirePackage{hyperref}
 \RequirePackage{kvoptions}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Se corrigen dos errores:
- El path a los archivos del último examen incorporado
- Un problema de librerías en LaTeX (probablemente se deba a alguna actualización de las herramientas)

He corrido la acción de build-pdfs en mi [fork](https://github.com/hakai-vulpes/material-docente) y ya funcionan.